### PR TITLE
Overlay support

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/layouts/LayoutFactory.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/LayoutFactory.java
@@ -17,7 +17,7 @@ public class LayoutFactory {
     }
 
     private static Layout createSingleScreenLayout(AppCompatActivity activity, ActivityParams params) {
-        return new SingleScreenLayout(activity, params.leftSideMenuParams, params.rightSideMenuParams, params.screenParams);
+        return new SingleScreenLayout(activity, params);
     }
 
     private static Layout createBottomTabsScreenLayout(AppCompatActivity activity, ActivityParams params) {

--- a/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.Promise;
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.events.EventBus;
 import com.reactnativenavigation.events.ScreenChangedEvent;
+import com.reactnativenavigation.params.ActivityParams;
 import com.reactnativenavigation.params.ContextualMenuParams;
 import com.reactnativenavigation.params.FabParams;
 import com.reactnativenavigation.params.LightBoxParams;
@@ -23,6 +24,8 @@ import com.reactnativenavigation.params.TitleBarLeftButtonParams;
 import com.reactnativenavigation.screens.NavigationType;
 import com.reactnativenavigation.screens.Screen;
 import com.reactnativenavigation.screens.ScreenStack;
+import com.reactnativenavigation.utils.ViewUtils;
+import com.reactnativenavigation.views.ContentOverlayView;
 import com.reactnativenavigation.views.LeftButtonOnClickListener;
 import com.reactnativenavigation.views.LightBox;
 import com.reactnativenavigation.views.SideMenu;
@@ -38,8 +41,11 @@ import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 public class SingleScreenLayout extends BaseLayout {
 
     protected final ScreenParams screenParams;
+    protected final ScreenParams overlayParams;
     private final SideMenuParams leftSideMenuParams;
     private final SideMenuParams rightSideMenuParams;
+    private RelativeLayout container;
+    private ContentOverlayView overlayView;
     protected ScreenStack stack;
     private SnackbarAndFabContainer snackbarAndFabContainer;
     protected LeftButtonOnClickListener leftButtonOnClickListener;
@@ -49,8 +55,18 @@ public class SingleScreenLayout extends BaseLayout {
 
     public SingleScreenLayout(AppCompatActivity activity, SideMenuParams leftSideMenuParams,
                               SideMenuParams rightSideMenuParams, ScreenParams screenParams) {
+        this(activity, leftSideMenuParams, rightSideMenuParams, screenParams, null);
+    }
+
+    public SingleScreenLayout(AppCompatActivity activity, ActivityParams params) {
+        this(activity, params.leftSideMenuParams, params.rightSideMenuParams, params.screenParams, params.overlayParams);
+    }
+
+    public SingleScreenLayout(AppCompatActivity activity, SideMenuParams leftSideMenuParams,
+                              SideMenuParams rightSideMenuParams, ScreenParams screenParams, ScreenParams overlayParams) {
         super(activity);
         this.screenParams = screenParams;
+        this.overlayParams = overlayParams;
         this.leftSideMenuParams = leftSideMenuParams;
         this.rightSideMenuParams = rightSideMenuParams;
         createLayout();
@@ -82,7 +98,19 @@ public class SingleScreenLayout extends BaseLayout {
         if (stack != null) {
             stack.destroy();
         }
-        stack = new ScreenStack(getActivity(), parent, screenParams.getNavigatorId(), this);
+
+        container = new RelativeLayout(getContext());
+        container.setId(ViewUtils.generateViewId());
+        LayoutParams containerLayoutParams = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
+        parent.addView(container, containerLayoutParams);
+
+        if (overlayParams != null) {
+            overlayView = new ContentOverlayView(getActivity(), overlayParams.screenId, overlayParams.navigationParams);
+            LayoutParams overlayViewLayoutParams = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
+            parent.addView(overlayView, overlayViewLayoutParams);
+        }
+
+        stack = new ScreenStack(getActivity(), container, screenParams.getNavigatorId(), this);
         LayoutParams lp = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
         pushInitialScreen(lp);
         pushAdditionalScreens(lp);
@@ -139,6 +167,15 @@ public class SingleScreenLayout extends BaseLayout {
     public void destroy() {
         stack.destroy();
         snackbarAndFabContainer.destroy();
+
+        RelativeLayout parentLayout = getScreenStackParent();
+
+        if (overlayView != null) {
+            overlayView.unmountReactView();
+            parentLayout.removeView(overlayView);
+        }
+        parentLayout.removeView(container);
+
         if (sideMenu != null) {
             sideMenu.destroy();
         }

--- a/android/app/src/main/java/com/reactnativenavigation/params/ActivityParams.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/ActivityParams.java
@@ -9,6 +9,7 @@ public class ActivityParams {
 
     public Type type;
     public ScreenParams screenParams;
+    public ScreenParams overlayParams;
     public List<ScreenParams> tabParams;
     public SideMenuParams leftSideMenuParams;
     public SideMenuParams rightSideMenuParams;

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
@@ -32,6 +32,10 @@ public class ActivityParamsParser extends Parser {
             result.rightSideMenuParams = sideMenus[SideMenu.Side.Right.ordinal()];
         }
 
+        if (hasKey(params, "overlay")) {
+            result.overlayParams = ScreenParamsParser.parse(params.getBundle("overlay"));
+        }
+
         result.animateShow = params.getBoolean("animateShow", true);
 
         return result;

--- a/android/app/src/main/java/com/reactnativenavigation/screens/ScreenStack.java
+++ b/android/app/src/main/java/com/reactnativenavigation/screens/ScreenStack.java
@@ -183,7 +183,7 @@ public class ScreenStack {
     }
 
     private void addScreenBeforeSnackbarAndFabLayout(Screen screen, LayoutParams layoutParams) {
-        parent.addView(screen, parent.getChildCount() - 1, layoutParams);
+        parent.addView(screen, parent.getChildCount(), layoutParams);
     }
 
     public void pop(boolean animated, double jsPopTimestamp) {

--- a/android/app/src/main/java/com/reactnativenavigation/views/ContentOverlayView.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/ContentOverlayView.java
@@ -1,0 +1,26 @@
+package com.reactnativenavigation.views;
+
+import android.content.Context;
+import android.view.MotionEvent;
+
+import com.facebook.react.uimanager.TouchTargetHelper;
+import com.reactnativenavigation.params.NavigationParams;
+
+/**
+ * Created by khmelev on 28/10/2017.
+ */
+
+public class ContentOverlayView extends ContentView {
+
+    public ContentOverlayView(Context context, String screenId, NavigationParams navigationParams) {
+        super(context, screenId, navigationParams);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+        super.onTouchEvent(ev);
+
+        int tag = TouchTargetHelper.findTargetTagForTouch(ev.getX(), ev.getY(), this);
+        return tag != this.getId();
+    }
+}

--- a/docs/top-level-api.md
+++ b/docs/top-level-api.md
@@ -90,6 +90,10 @@ Navigation.startTabBasedApp({
                                         // for TheSideBar: 'airbnb', 'facebook', 'luvocracy','wunder-list'
     disableOpenGesture: false // optional, can the drawer be opened with a swipe instead of button
   },
+  overlay: { // optional, add this if you want an overlay view over your tabs (iOS only)
+    screen: 'example.OverlayScreen', // unique ID registered with Navigation.registerScreen
+    passProps: {} // simple serializable object that will pass as props to all top screens (optional)
+  },  
   passProps: {}, // simple serializable object that will pass as props to all top screens (optional)
   animationType: 'slide-down' // optional, add transition animation to root change: 'none', 'slide-down', 'fade'
 });
@@ -135,6 +139,10 @@ Navigation.startSingleScreenApp({
     // for TheSideBar: 'airbnb', 'facebook', 'luvocracy','wunder-list'
     disableOpenGesture: false // optional, can the drawer, both right and left, be opened with a swipe instead of button
   },
+  overlay: { // optional, add this if you want an overlay view over your navigation controller (iOS only)
+    screen: 'example.OverlayScreen', // unique ID registered with Navigation.registerScreen
+    passProps: {} // simple serializable object that will pass as props to all top screens (optional)
+  },  
   passProps: {}, // simple serializable object that will pass as props to all top screens (optional)
   animationType: 'slide-down' // optional, add transition animation to root change: 'none', 'slide-down', 'fade'
 });
@@ -208,6 +216,25 @@ Navigation.handleDeepLink({
   link: 'link/in/any/format',
   payload: '' // (optional) Extra payload with deep link
 });
+```
+
+## showOverlay(params = {})
+
+Show new overlay or replace currently visible overlay (iOS only)
+
+```js
+Navigation.showOverlay({
+  screen: 'example.OverlayScreen', // unique ID registered with Navigation.registerScreen
+  passProps: {} // simple serializable object that will pass as props to all top screens (optional)
+});
+```
+
+## removeOverlay()
+
+Remove currently visible overlay (iOS only)
+
+```js
+Navigation.removeOverlay();
 ```
 
 ## registerScreen(screenID, generator)

--- a/ios/RCCManagerModule.m
+++ b/ios/RCCManagerModule.m
@@ -412,6 +412,24 @@ RCT_EXPORT_METHOD(getCurrentlyVisibleScreenId:(RCTPromiseResolveBlock)resolve re
     resolve(result);
 }
 
+RCT_EXPORT_METHOD(
+                  showOverlay:(NSDictionary*)params)
+{
+    UIViewController *rootVC = [UIApplication sharedApplication].delegate.window.rootViewController;
+    if ([rootVC respondsToSelector:@selector(showOverlay:)]) {
+        [rootVC performSelector:@selector(showOverlay:) withObject:params];
+    }
+}
+
+RCT_EXPORT_METHOD(
+                  removeOverlay)
+{
+    UIViewController *rootVC = [UIApplication sharedApplication].delegate.window.rootViewController;
+    if ([rootVC respondsToSelector:@selector(removeOverlay)]) {
+        [rootVC performSelector:@selector(removeOverlay)];
+    }
+}
+
 -(BOOL)viewControllerIsModal:(UIViewController*)viewController
 {
     BOOL viewControllerIsModal = (viewController.presentingViewController.presentedViewController == viewController)

--- a/ios/RCCNavigationController.h
+++ b/ios/RCCNavigationController.h
@@ -5,5 +5,7 @@
 
 - (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge;
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge;
+- (void)showOverlay:(NSDictionary *)params;
+- (void)removeOverlay;
 
 @end

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -15,6 +15,12 @@
 #import "RCTHelpers.h"
 #import "RCTConvert+UIBarButtonSystemItem.h"
 
+@interface RCCNavigationController()
+
+@property (strong, nonatomic) RCTRootView *overlayView;
+
+@end
+
 @implementation RCCNavigationController
 {
   BOOL _transitioning;
@@ -35,6 +41,8 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   
   NSString *component = props[@"component"];
   if (!component) return nil;
+  
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onRNReload) name:RCTJavaScriptWillStartLoadingNotification object:nil];
   
   NSDictionary *passProps = props[@"passProps"];
   NSDictionary *navigatorStyle = props[@"style"];
@@ -67,6 +75,20 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   
 
   [self setRotation:props];
+
+  NSString *overlayScreen = [props valueForKeyPath:@"overlay.screen"];
+  if (overlayScreen) {
+    // Pass navigation props
+    NSMutableDictionary *mutablePassPropsOverlay = [passProps mutableCopy];
+    NSDictionary *overlayProps = [props valueForKeyPath:@"overlay.passProps"];
+    if (overlayProps) {
+      [mutablePassPropsOverlay addEntriesFromDictionary:overlayProps];
+    }
+
+    NSDictionary *passPropsOverlay = [NSDictionary dictionaryWithDictionary:mutablePassPropsOverlay];
+    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayScreen initialProperties:passPropsOverlay];
+  }
+
   
   NSArray* components = props[@"components"];
   if (components.count) {
@@ -80,6 +102,52 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   return self;
 }
 
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTJavaScriptWillStartLoadingNotification object:nil];
+  self.overlayView = nil;
+}
+
+- (void)onRNReload {
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTJavaScriptWillStartLoadingNotification object:nil];
+  self.overlayView = nil;
+}
+
+- (void)showOverlay:(NSDictionary *)params {
+  NSString *overlayScreen = [params valueForKeyPath:@"screen"];
+  NSDictionary *overlayProps = [params valueForKeyPath:@"passProps"];
+  self.overlayView = [[RCTRootView alloc] initWithBridge:[[RCCManager sharedInstance] getBridge] moduleName:overlayScreen initialProperties:overlayProps];
+}
+
+- (void)removeOverlay {
+  self.overlayView = nil;
+}
+
+- (void)setOverlayView:(RCTRootView *)overlayView {
+  RCTRootView *previousOverlayView = _overlayView;
+
+  if (previousOverlayView) {
+    [previousOverlayView removeFromSuperview];
+  }
+
+  _overlayView = overlayView;
+
+  if (!_overlayView) {
+    return;
+  }
+
+  _overlayView.passThroughTouches = YES;
+  _overlayView.backgroundColor = [UIColor clearColor];
+  _overlayView.frame = self.view.bounds;
+  [self.view addSubview:_overlayView];
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+  
+  if (_overlayView) {
+    [self.view bringSubviewToFront:_overlayView];
+  }
+}
 
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge
 {

--- a/ios/RCCTabBarController.h
+++ b/ios/RCCTabBarController.h
@@ -5,6 +5,8 @@
 
 - (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge;
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge completion:(void (^)(void))completion;
+- (void)showOverlay:(NSDictionary *)params;
+- (void)removeOverlay;
 
 @property (nonatomic) BOOL tabBarHidden;
 

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -91,7 +91,6 @@
   UIColor *selectedButtonColor = nil;
   UIColor *labelColor = nil;
   UIColor *selectedLabelColor = nil;
-  NSDictionary *passProps = props[@"passProps"];
   NSDictionary *tabsStyle = props[@"style"];
   if (tabsStyle)
   {
@@ -144,14 +143,8 @@
   NSString *overlayScreen = [props valueForKeyPath:@"overlay.screen"];
   if (overlayScreen) {
     // Pass navigation props
-    NSMutableDictionary *mutablePassPropsOverlay = [passProps mutableCopy];
     NSDictionary *overlayProps = [props valueForKeyPath:@"overlay.passProps"];
-    if (overlayProps) {
-      [mutablePassPropsOverlay addEntriesFromDictionary:overlayProps];
-    }
-    
-    NSDictionary *passPropsOverlay = [NSDictionary dictionaryWithDictionary:mutablePassPropsOverlay];
-    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayScreen initialProperties:passPropsOverlay];
+    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayScreen initialProperties:overlayProps];
   }
   
   NSMutableArray *viewControllers = [NSMutableArray array];
@@ -285,7 +278,7 @@
   [super viewDidLayoutSubviews];
   
   if (_overlayView) {
-    [self.view bringSubviewToFront:_overlayView];
+    [self.view bringSubviewToFront:self.tabBar];
   }
 }
 

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -14,6 +14,12 @@
 
 @end
 
+@interface RCCTabBarController()
+
+@property (strong, nonatomic) RCTRootView *overlayView;
+
+@end
+
 @implementation RCCTabBarController
 
 
@@ -133,6 +139,18 @@
     }
   }
   
+  NSString *overlayScreen = [props valueForKeyPath:@"overlay.screen"];
+  if (overlayScreen) {
+    // Pass navigation props
+    NSMutableDictionary *mutablePassPropsOverlay = [passProps mutableCopy];
+    NSDictionary *overlayProps = [props valueForKeyPath:@"overlay.passProps"];
+    if (overlayProps) {
+      [mutablePassPropsOverlay addEntriesFromDictionary:overlayProps];
+    }
+    NSDictionary *passPropsOverlay = [NSDictionary dictionaryWithDictionary:mutablePassPropsOverlay];
+    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayScreen initialProperties:passPropsOverlay];
+  }
+  
   NSMutableArray *viewControllers = [NSMutableArray array];
   
   // go over all the tab bar items
@@ -229,6 +247,33 @@
   [self setRotation:props];
   
   return self;
+}
+
+- (void)setOverlayView:(RCTRootView *)overlayView {
+  RCTRootView *previousOverlayView = _overlayView;
+
+  if (previousOverlayView) {
+    [previousOverlayView removeFromSuperview];
+  }
+  
+  _overlayView = overlayView;
+  
+  if (!_overlayView) {
+    return;
+  }
+  
+  _overlayView.passThroughTouches = YES;
+  _overlayView.backgroundColor = [UIColor clearColor];
+  _overlayView.frame = self.view.bounds;
+  [self.view addSubview:_overlayView];
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+ 
+  if (_overlayView) {
+    [self.view bringSubviewToFront:_overlayView];
+  }
 }
 
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge completion:(void (^)(void))completion

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -235,7 +235,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 
 - (void)sendGlobalScreenEvent:(NSString *)eventName endTimestampString:(NSString *)endTimestampStr shouldReset:(BOOL)shouldReset {
   
-  if (!self.commandType) return;
+//  if (!self.commandType) return;
   
   if ([self.view isKindOfClass:[RCTRootView class]]){
     NSString *screenName = [((RCTRootView*)self.view) moduleName];

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -182,6 +182,14 @@ function getCurrentlyVisibleScreenId() {
   return platformSpecific.getCurrentlyVisibleScreenId();
 }
 
+function showOverlay(params = {}) {
+  return platformSpecific.showOverlay(params);
+}
+
+function removeOverlay() {
+  return platformSpecific.removeOverlay();
+}
+
 async function getLaunchArgs() {
   return await platformSpecific.getLaunchArgs();
 }
@@ -205,5 +213,6 @@ export default {
   handleDeepLink: handleDeepLink,
   isAppLaunched: isAppLaunched,
   isRootLaunched: isRootLaunched,
-  getLaunchArgs
+  showOverlay: showOverlay,
+  removeOverlay: removeOverlay
 };

--- a/src/deprecated/controllers/index.js
+++ b/src/deprecated/controllers/index.js
@@ -322,6 +322,12 @@ var Controllers = {
   ScreenUtils: {
     getCurrentlyVisibleScreenId: async function() {
       return await RCCManager.getCurrentlyVisibleScreenId();
+    },
+    showOverlay: function(params) {
+      RCCManager.showOverlay(params);
+    },
+    removeOverlay: function() {
+      RCCManager.removeOverlay();
     }
   },
 

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -867,7 +867,7 @@ export default {
   isRootLaunched,
   getCurrentlyVisibleScreenId,
   showOverlay,
-  removeOverlay
+  removeOverlay,
   getCurrentlyVisibleScreenId,
   getLaunchArgs
 };

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -32,6 +32,9 @@ async function startSingleScreenApp(params) {
     if (params.appStyle) {
       params.appStyle.orientation = getOrientation(params);
     }
+    if (params.overlay) {
+        params.overlay = createOverlay(params.overlay)
+    }
 
   return await newPlatformSpecific.startApp(params);
 }
@@ -256,6 +259,19 @@ function convertStyleParams(originalStyleObject) {
     ret.topBarReactViewInitialProps = {passPropsKey};
   }
   return ret;
+}
+
+function createOverlay(overlayParams) {
+  if (!overlayParams.screen) {
+    console.error('createOverlay(overlayParams): overlay must include a screen property');
+    return;
+  }
+
+  let result = Object.assign({}, overlayParams);
+  result.screenId = result.screen;
+  addNavigatorParams(result);
+  result = adaptNavigationParams(result);
+  return result
 }
 
 function convertDrawerParamsToSideMenuParams(drawerParams) {
@@ -794,6 +810,13 @@ function dismissContextualMenu() {
   newPlatformSpecific.dismissContextualMenu();
 }
 
+function showOverlay(params) {
+}
+
+function removeOverlay() {
+}
+
+
 async function isAppLaunched() {
   return await newPlatformSpecific.isAppLaunched();
 }
@@ -842,6 +865,9 @@ export default {
   dismissContextualMenu,
   isAppLaunched,
   isRootLaunched,
+  getCurrentlyVisibleScreenId,
+  showOverlay,
+  removeOverlay
   getCurrentlyVisibleScreenId,
   getLaunchArgs
 };

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -53,6 +53,24 @@ async function startTabBasedApp(params) {
     };
   });
 
+  if (params.overlay && params.overlay.screen) {
+    const screenInstanceID = _.uniqueId('screenInstanceID')
+    const navigatorID = controllerID + '_overlay'
+    const {
+        navigatorStyle,
+        navigatorButtons,
+        navigatorEventID
+    } = _mergeScreenSpecificSettings(params.overlay.screen, screenInstanceID, params.overlay);
+    params.overlay.passProps = {
+        ...params.overlay.passProps,
+        navigatorID,
+        screenInstanceID,
+        navigatorStyle,
+        navigatorButtons,
+        navigatorEventID,
+    }
+  }
+
   const Controller = Controllers.createClass({
     render: function() {
       if (!params.drawer || (!params.drawer.left && !params.drawer.right)) {
@@ -688,6 +706,37 @@ function savePassProps(params) {
 }
 
 function showOverlay(params) {
+    if (!params.screen) {
+        console.error('showOverlay(params): params.screen is required');
+        return;
+    }
+
+    const controllerID = _.uniqueId('controllerID');
+    const navigatorID = controllerID + '_overlay';
+    const screenInstanceID = _.uniqueId('screenInstanceID');
+    const {
+        navigatorStyle,
+        navigatorButtons,
+        navigatorEventID
+    } = _mergeScreenSpecificSettings(params.screen, screenInstanceID, params);
+    const passProps = Object.assign({}, params.passProps);
+    passProps.navigatorID = navigatorID;
+    passProps.screenInstanceID = screenInstanceID;
+    passProps.navigatorEventID = navigatorEventID;
+
+    params.navigationParams = {
+        screenInstanceID,
+        navigatorStyle,
+        navigatorButtons,
+        navigatorEventID,
+        navigatorID
+    };
+
+    savePassProps(params);
+    params.passProps = passProps;
+
+  savePassProps(params);
+
   ScreenUtils.showOverlay(params)
 }
 

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -96,8 +96,8 @@ async function startTabBasedApp(params) {
           id={controllerID + '_tabs'}
           style={params.tabsStyle}
           appStyle={params.appStyle}
-          initialTabIndex={params.initialTabIndex}>
-          overlay={params.overlay}
+          initialTabIndex={params.initialTabIndex}
+          overlay={params.overlay}>
           {
             params.tabs.map(function (tab, index) {
               return (
@@ -214,6 +214,7 @@ async function startSingleScreenApp(params) {
           subtitle={params.subtitle}
           titleImage={screen.titleImage}
           component={screen.screen}
+          overlay={params.overlay}
           components={components}
           passProps={passProps}
           style={navigatorStyle}
@@ -686,6 +687,14 @@ function savePassProps(params) {
   }
 }
 
+function showOverlay(params) {
+  ScreenUtils.showOverlay(params)
+}
+
+function removeOverlay() {
+  ScreenUtils.removeOverlay()
+}
+
 function showContextualMenu() {
   // Android only
 }
@@ -753,6 +762,9 @@ export default {
   navigatorToggleNavBar,
   showContextualMenu,
   dismissContextualMenu,
+  getCurrentlyVisibleScreenId,
+  showOverlay,
+  removeOverlay
   getCurrentlyVisibleScreenId,
   getLaunchArgs
 };

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -97,6 +97,7 @@ async function startTabBasedApp(params) {
           style={params.tabsStyle}
           appStyle={params.appStyle}
           initialTabIndex={params.initialTabIndex}>
+          overlay={params.overlay}
           {
             params.tabs.map(function (tab, index) {
               return (

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -764,7 +764,7 @@ export default {
   dismissContextualMenu,
   getCurrentlyVisibleScreenId,
   showOverlay,
-  removeOverlay
+  removeOverlay,
   getCurrentlyVisibleScreenId,
   getLaunchArgs
 };

--- a/src/platformSpecific.android.js
+++ b/src/platformSpecific.android.js
@@ -120,6 +120,10 @@ function savePassProps(params) {
   if (params.sideMenu && params.sideMenu.right) {
     PropRegistry.save(params.sideMenu.right.navigationParams.screenInstanceID, params.sideMenu.right.passProps);
   }
+
+  if (params.overlay) {
+    PropRegistry.save(params.overlay.navigationParams.screenInstanceID, params.overlay.passProps);
+  }
 }
 
 function toggleSideMenuVisible(animated, side) {


### PR DESCRIPTION
Adds support for an overlay view, which will sit behind the tabBar but over all other views in the navigation stack.

Known issues: Technically there is support for hide/show overlay, but only overlays created when the tabBasedApp is started will have access to hide/show the tabBar. To work around this issue we don't hide the overlay once created and instead hide the player. I'm not sure of an easy way to handle this without getting access to the tab controllerID when showOverlay is called. That would require that it gets set when the tab controller is created.

Most of this work will be irrelevant when V2 of this library is finished, but we needed support for the player without including a player component on every screen. This works nicely.